### PR TITLE
feat(fixed): set width as fixed and improve colors

### DIFF
--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -101,7 +101,11 @@ const App = () => {
 
         if (currentTab === 2) {
             if (!mrData.issuesAssigned || mrData.issuesAssigned.length === 0) {
-                return <img src={emptyInbox} className={'emptyInbox'} />;
+                return (
+                    <div className={'emptyContainer'}>
+                        <img src={emptyInbox} className={'emptyInbox'} />
+                    </div>
+                );
             }
             return (
                 <FilterList className={'mrList'}>
@@ -114,7 +118,11 @@ const App = () => {
 
         if (currentTab === 3) {
             if (!mrData.todos || mrData.todos.length === 0) {
-                return <img src={emptyInbox} className={'emptyInbox'} />;
+                return (
+                    <div className={'emptyContainer'}>
+                        <img src={emptyInbox} className={'emptyInbox'} />
+                    </div>
+                );
             }
             return (
                 <FilterList className={'mrList'}>
@@ -167,7 +175,7 @@ const App = () => {
     return (
         <ThemeProvider theme={primer}>
             <div className={'container'}>
-                <TabNav aria-label="Main" mb={2}>
+                <TabNav aria-label="Main" mb={2} marginBottom="0">
                     <TabNav.Link
                         href="#ToReview"
                         onClick={() => setCurrentTab(0)}

--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -1,9 +1,10 @@
 body {
+    background: #fafbfc;
     font-family: Arial;
 }
 
 .container {
-    min-width: 500px;
+    width: 700px;
 }
 
 .hidden {
@@ -11,8 +12,16 @@ body {
 }
 
 .mrList {
+    background: white;
+    /* border-color matches TabNav lib */
+    border-right: 1px solid rgb(225, 228, 232);
+    border-bottom: 1px solid rgb(225, 228, 232);
+    border-left: 1px solid rgb(225, 228, 232);
     overflow: auto;
-    overflow: overlay; /* This is a fix for Chrome */
+    /* This is a fix for Chrome */
+    overflow: overlay;
+    /* Override default styles */
+    padding: 6px !important;
     max-height: 434px;
 }
 
@@ -26,8 +35,7 @@ body {
     display: block;
     text-decoration: none;
     color: black !important;
-
-    max-width: 530px;
+    max-width: 500px;
     text-overflow: ellipsis;
     overflow: hidden;
 }
@@ -37,6 +45,7 @@ body {
     text-overflow: ellipsis;
     overflow: hidden;
     cursor: pointer;
+    max-width: 250px;
 }
 
 .mrLabel {
@@ -86,7 +95,7 @@ body {
 
 .moreAssigneesIcon {
     display: inline-block;
-    background: #eee;
+    background: #ddd;
     max-height: 40px;
     vertical-align: middle;
     text-align: center;
@@ -96,7 +105,12 @@ body {
 }
 
 .moreAssigneesIcon:hover {
-    background: #ddd;
+    background: #ccc;
+}
+
+.emptyContainer {
+    background: white;
+    display: flex;
 }
 
 .emptyInbox {


### PR DESCRIPTION
The fact that the tabs moved and width changed making it harder to navigate between tabs bothered me a bit so I created a fixed width and made the necessary changes to accommodate it. Also in the same PR I modified a few colors to have a light grey background with the active tab and its contents in white so it will be clearer which tab you are on. (I also think it jazzes things up a bit but that's just my personal opinion :))

![gitlab-fixed-width-colors](https://user-images.githubusercontent.com/5795115/84537743-5949e480-acbe-11ea-815e-ccf4cd8a3e05.gif)