### PR TITLE
Fix error when there are no reviewers in GitLab's response

### DIFF
--- a/src/background/types.ts
+++ b/src/background/types.ts
@@ -12,7 +12,7 @@ export interface MergeRequests {
     web_url: string;
     author: User;
     assignees: User[];
-    reviewers: User[];
+    reviewers?: User[];
     user_notes_count: number;
     references: References;
     // missing types here

--- a/src/popup/components/MergeRequestItem.tsx
+++ b/src/popup/components/MergeRequestItem.tsx
@@ -30,7 +30,7 @@ export const MergeRequestItem = ({ mr }: Props) => {
         setCopyBranchStatus(true);
     };
 
-    const reviewers = removeDuplicateObjectFromArray([...mr.assignees, ...mr.reviewers], 'id');
+    const reviewers = removeDuplicateObjectFromArray([...mr.assignees, ...(mr.reviewers ?? [])], 'id');
 
     const avatars = reviewers
         .map((assignee) => {


### PR DESCRIPTION
I encountered the following error and noticed that GitLab didn't return an array of reviewers from the merge requests API. Mark the `reviewers` property as optional.
 
<img width="1340" alt="error" src="https://user-images.githubusercontent.com/16533168/106265687-5bb77980-6262-11eb-98da-fa91b9167c9a.png">
