### PR TITLE
Feature/create vip user

### DIFF
--- a/src/background/endpoints/getLatestDataFromGitLab.ts
+++ b/src/background/endpoints/getLatestDataFromGitLab.ts
@@ -186,6 +186,8 @@ export const getLatestDataFromGitLab = (cb: CallbackErrorOnly) => {
                                 }
                             });
 
+                            console.log(mrReceivedDetails);
+
                             return cb(null, {
                                 mrReceived,
                                 mrVips,

--- a/src/background/endpoints/getLatestDataFromGitLab.ts
+++ b/src/background/endpoints/getLatestDataFromGitLab.ts
@@ -98,15 +98,17 @@ export const getLatestDataFromGitLab = (cb: CallbackErrorOnly) => {
             ],
             assignedRequests: [
                 'gitlabApi',
+                'currentUser',
                 (results, cb) => {
-                    const { gitlabApi } = results;
+                    const { gitlabApi, currentUser } = results;
 
                     gitlabApi.MergeRequests.all({
                         state: 'opened',
                         scope: 'assigned_to_me'
                     })
                         .then((mrReceived: MergeRequests[]) => {
-                            return cb(null, mrReceived);
+                            const filteredOutAutoAssigned = mrReceived.filter((mr) => mr.author.id !== currentUser.id);
+                            return cb(null, filteredOutAutoAssigned);
                         })
                         .catch((error: Error) => {
                             if (error) {

--- a/src/background/endpoints/getLocalData.ts
+++ b/src/background/endpoints/getLocalData.ts
@@ -11,9 +11,11 @@ export const getLocalData = (global_error: Error | null) => {
             'mrGiven',
             'mrToReview',
             'mrReviewed',
+            'mrVips',
             'issuesAssigned',
             'todos',
-            'lastUpdateDateUnix'
+            'lastUpdateDateUnix',
+            'vipUsers'
         ])
     );
 };

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -17,6 +17,7 @@ const App = () => {
         mrReceived: [],
         mrToReview: 0,
         mrGiven: [],
+        mrVips: [],
         mrReviewed: 0,
         issuesAssigned: [],
         todos: [],

--- a/src/popup/components/Content.tsx
+++ b/src/popup/components/Content.tsx
@@ -83,7 +83,8 @@ export const Content = (props: Props) => {
     // show data
     let mrList: MergeRequestsDetails[] = [];
     if (currentTab === 0) {
-        mrList = mrData.mrReceived;
+        // Pushing VIPs request on top of the list
+        mrList = [...mrData.mrVips, ...mrData.mrReceived];
     } else {
         mrList = mrData.mrGiven;
     }

--- a/src/popup/utils/mergeRequestDownloader.ts
+++ b/src/popup/utils/mergeRequestDownloader.ts
@@ -7,6 +7,7 @@ export interface MergeRequestSendMessageReply {
     mrReceived: MergeRequestsDetails[];
     mrToReview: number;
     mrGiven: MergeRequestsDetails[];
+    mrVips: MergeRequestsDetails[];
     mrReviewed: number;
     issuesAssigned: Issue[];
     todos: Todo[];
@@ -38,6 +39,7 @@ export const getMergeRequestList = (): Promise<MergeRequestSendMessageReply> => 
                 mrReceived: [],
                 mrToReview: 0,
                 mrGiven: [],
+                mrVips: [],
                 mrReviewed: 0,
                 issuesAssigned: [],
                 todos: [],


### PR DESCRIPTION
**Problem:** 
Everyday I receive to many MRs and and some people in my team needs more attention than others. I want to be able to highlight those people MRs.

**Solution:**
I introduced the notion of VIPs and push their MRs on top of the list. So I can focus on this MRs in priority.
This proposition is a quickfix as it is my interaction with the product and not very familiar with just yet. 
For now to create the list of VIPs we need to create the `vipUsers` array manually in the chrome storage. But I imagine a solution in the future where we can just select the users from the extension.

**List of changes:**
* Added the notions of `vipUsers` to be read from chrome storage.
* Split all received MRs in in 2 lists `mrVip` (listing all MRs from VIPs) and `mrReceived` (listing all MRs from non VIPs)
* Bonus change: I filter out the current user from "Assigned" MRs
 
**Ideas for the futur:**
I imagine a better solution too where this list of VIPs could be extend not only to the MRs I am assigned to as a reviewer. But more "I want to follow this user. List me all his MRs" 
Same with certain projects. "I want to follow along what is happening in this code base. Show me all MRs changing this part of the codebase".