### PR TITLE
fix(mr-list): remove mrs current user created from requested list

### DIFF
--- a/src/background/endpoints/getLatestDataFromGitLab.ts
+++ b/src/background/endpoints/getLatestDataFromGitLab.ts
@@ -17,13 +17,19 @@ export const getLatestDataFromGitLab = async (): Promise<void> => {
         state: 'opened',
         scope: 'assigned_to_me'
     });
+
     const mrReceived = await gitlabApi.MergeRequests.all({
         state: 'opened',
         scope: 'all',
         reviewer_id: currentUser.id
     });
 
-    const requests = removeDuplicateObjectFromArray([...mrAssigned, ...mrReceived], 'iid');
+    // On gitlab you can be the author of an MR, tagged as assignee or reviewer
+    // or all at the same time. We clean all unnecessary duplicates and MRs
+    // current user is the creator of from the requests list.
+    const requests = removeDuplicateObjectFromArray([...mrAssigned, ...mrReceived], 'iid').filter(
+        (merge) => merge.author.id !== currentUser.id
+    );
 
     const mrReceivedDetails = await fetchMRExtraInfo({
         gitlabApi,

--- a/src/popup/components/AvatarWithTooltip.tsx
+++ b/src/popup/components/AvatarWithTooltip.tsx
@@ -3,7 +3,7 @@ import { Avatar, Tooltip } from '@primer/react';
 import { CheckIcon } from '@primer/octicons-react';
 import { GitlabTypes } from '../../background/types';
 
-interface UserWithApproval extends GitlabTypes.UserSchema {
+export interface UserWithApproval extends GitlabTypes.UserSchema {
     approved?: boolean;
 }
 

--- a/src/popup/components/MergeRequestItem.tsx
+++ b/src/popup/components/MergeRequestItem.tsx
@@ -8,7 +8,7 @@ import {
     CommentDiscussionIcon,
     PlusIcon
 } from '@primer/octicons-react';
-import { AvatarWithTooltip } from './AvatarWithTooltip';
+import { AvatarWithTooltip, UserWithApproval } from './AvatarWithTooltip';
 import { calculateTimeElapsed, removeDuplicateObjectFromArray } from '../helpers';
 import { GitlabTypes, MergeRequestsDetails } from '../../background/types';
 
@@ -35,6 +35,10 @@ export const MergeRequestItem = ({ mr }: Props) => {
 
     const avatars = reviewers
         .map((assignee) => {
+            // In TS spread operator loses the typing. Because of Omit
+            // I am not sure loses even more. Resulting type is { approve: boolean | undefined}
+            // Because assignee is type of Omit<GitlabTypes.UserSchema, 'created_at'>
+            // it is safe to cast output type to a UserWithApproval type
             return {
                 ...assignee,
                 approved:
@@ -43,7 +47,7 @@ export const MergeRequestItem = ({ mr }: Props) => {
                     mr.approvals.approved_by.filter((approval) => {
                         return approval.user.id === assignee.id;
                     }).length > 0
-            };
+            } as UserWithApproval;
         })
         .sort((a, b) => Number(b.approved) - Number(a.approved))
         .slice(0, 3);

--- a/src/popup/helpers.ts
+++ b/src/popup/helpers.ts
@@ -23,6 +23,6 @@ export const getHumanReadableDate = (timestamp: number) => {
     return new Date(timestamp).toUTCString();
 };
 
-export const removeDuplicateObjectFromArray = (array: any[], key: string) => {
+export const removeDuplicateObjectFromArray = <T>(array: T[], key: string): T[] => {
     return array.filter((obj, index, self) => index === self.findIndex((element) => element[key] === obj[key]));
 };


### PR DESCRIPTION
On Gitlab you can be the creator of an MR and be tagged as a reviewer and / or an assignee. 

[Gitlab documentation](https://docs.gitlab.cn/14.0/ee/user/project/merge_requests/getting_started.html#reviewer) is not super clear on what exactly is the role of an Assignee. But it compares the Reviewer and the Assignee as: _"In comparison to an Assignee, **who is directly responsible for creating or merging a merge request**, a Reviewer is a team member who may only be involved in one aspect of the merge request, such as a peer review."_ 
Thus I think it is not rare that the creator of the MR is also tagged as the Assignee.

This MR filters out from the list of request, MRs created by the user. This generates noise in the "To Review" tab and is redundant information with the "Under Review" tab

I also took the opportunity to slightly improve the `removeDuplicateObjectFromArray` typings. By adding generic which will infer the output type from the param's type.