### PR TITLE
Display pipeline statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ _Don't miss any GitLab merge requests or issues and rocket up your productivity.
 -   List Issues you are assigned to
 -   Display your To-Do List
 -   Pick a random contributor of a repository to assign them to a MR 😈
+-   Display the pipelines statuses and unresolved threads for merges requests
 
 It comes with a bunch of features to let you access easily the information you're looking for and is customizable so it fits your needs.
 

--- a/src/background/types.ts
+++ b/src/background/types.ts
@@ -5,6 +5,7 @@ export type GitlabAPI = InstanceType<typeof Gitlab>;
 
 export interface MergeRequestsDetails extends GitlabTypes.MergeRequestSchema {
     approvals: Approvals | GitlabTypes.MergeRequestLevelMergeRequestApprovalSchema;
+    pipeline?: GitlabTypes.PipelineSchema;
 }
 
 export interface Approvals {

--- a/src/popup/components/MergeBadge.tsx
+++ b/src/popup/components/MergeBadge.tsx
@@ -1,0 +1,38 @@
+import { Label } from '@primer/react';
+import { GitMergeIcon, GitPullRequestDraftIcon, GitPullRequestClosedIcon } from '@primer/octicons-react';
+import { GitlabTypes } from '../../background/types';
+
+interface Props {
+    mergeStatus: GitlabTypes.MergeRequestSchema['merge_status'];
+    mrApproved: boolean;
+}
+
+export const MergeBadge = (props: Props) => {
+    const { mergeStatus, mrApproved } = props;
+
+    let bg = 'danger.emphasis';
+    let title = 'Cannot be merged, you may need to rebase first.';
+    let icon = <GitPullRequestClosedIcon />;
+
+    if (mergeStatus === 'can_be_merged' && mrApproved) {
+        bg = 'success.emphasis';
+        title = 'Approved and mergeable!';
+        icon = <GitMergeIcon />;
+    }
+
+    if (mergeStatus !== 'can_be_merged' && mrApproved) {
+        bg = 'attention.emphasis';
+        title = 'Approved but you may need to rebase before merging.';
+        icon = <GitPullRequestDraftIcon />;
+    }
+
+    if (mergeStatus !== 'can_be_merged' && !mrApproved) {
+        return (
+            <Label size="small" sx={{ color: 'canvas.default', bg }} className={'mrLabel'} title={title}>
+                {icon}
+            </Label>
+        );
+    }
+
+    return <></>;
+};

--- a/src/popup/components/MergeRequestItem.tsx
+++ b/src/popup/components/MergeRequestItem.tsx
@@ -1,17 +1,12 @@
 import { useState } from 'react';
 import { Avatar, BranchName, FilterList, Box, Link, Label, Tooltip } from '@primer/react';
-import {
-    GitMergeIcon,
-    IssueClosedIcon,
-    IssueOpenedIcon,
-    ClockIcon,
-    CommentDiscussionIcon,
-    PlusIcon
-} from '@primer/octicons-react';
+import { GitMergeIcon, ClockIcon, CommentDiscussionIcon, PlusIcon } from '@primer/octicons-react';
 import { AvatarWithTooltip, UserWithApproval } from './AvatarWithTooltip';
 import { calculateTimeElapsed, cleanupDescription, removeDuplicateObjectFromArray } from '../helpers';
 import { GitlabTypes, MergeRequestsDetails } from '../../background/types';
 import { createNewTab } from '../utils/createNewTab';
+import { PipelineBadge } from './PipelineBadge';
+import { MergeBadge } from './MergeBadge';
 
 interface Props {
     mr: MergeRequestsDetails;
@@ -93,36 +88,8 @@ export const MergeRequestItem = ({ mr }: Props) => {
                                 <GitMergeIcon /> {mr.references.full}
                             </BranchName>
                         </Tooltip>
-                        {mr.merge_status === 'can_be_merged' && mr.approvals.approved ? (
-                            <Label
-                                size="small"
-                                sx={{ color: 'canvas.default', bg: 'success.emphasis' }}
-                                className={'mrLabel'}
-                                title="Approved and can be merged!"
-                            >
-                                <IssueClosedIcon />
-                            </Label>
-                        ) : null}
-                        {mr.merge_status !== 'can_be_merged' && mr.approvals.approved ? (
-                            <Label
-                                size="small"
-                                sx={{ color: 'canvas.default', bg: 'attention.emphasis' }}
-                                className={'mrLabel'}
-                                title="Approved but you may need to rebase before merging."
-                            >
-                                <IssueOpenedIcon />
-                            </Label>
-                        ) : null}
-                        {mr.merge_status !== 'can_be_merged' && !mr.approvals.approved ? (
-                            <Label
-                                size="small"
-                                sx={{ color: 'canvas.default', bg: 'danger.emphasis' }}
-                                className={'mrLabel'}
-                                title="Cannot be merged, you may need to rebase first."
-                            >
-                                <IssueOpenedIcon />
-                            </Label>
-                        ) : null}
+                        <PipelineBadge pipeline={mr.pipeline} />
+                        <MergeBadge mergeStatus={mr.merge_status} mrApproved={Boolean(mr.approvals.approved)} />
                         <Label
                             size="small"
                             sx={{

--- a/src/popup/components/PipelineBadge.tsx
+++ b/src/popup/components/PipelineBadge.tsx
@@ -1,0 +1,53 @@
+import { Label, useTheme } from '@primer/react';
+import { CheckIcon, XIcon, IterationsIcon } from '@primer/octicons-react';
+import { GitlabTypes } from '../../background/types';
+import { createNewTab } from '../utils/createNewTab';
+
+interface Props {
+    pipeline?: GitlabTypes.PipelineSchema;
+}
+
+export const PipelineBadge = (props: Props) => {
+    const { pipeline } = props;
+    const { theme } = useTheme();
+
+    if (!pipeline) {
+        return <></>;
+    }
+
+    let bg = 'attention.emphasis';
+    let title = `Pipeline is ${pipeline.status}`;
+    let icon = <IterationsIcon />;
+
+    if (pipeline.status === 'success') {
+        bg = 'success.emphasis';
+        title = 'Pipeline succeeded';
+        icon = <CheckIcon />;
+    }
+
+    if (pipeline.status === 'failed') {
+        bg = 'danger.emphasis';
+        title = 'Pipeline failed';
+        icon = <XIcon />;
+    }
+
+    const bgSplit = bg.split('.');
+
+    return (
+        <Label
+            size="small"
+            sx={{
+                'color': 'canvas.default',
+                bg,
+                'padding': '0 3px',
+                'cursor': 'pointer',
+                ':hover': { boxShadow: `0px 0px 5px 0px ${theme?.colors[bgSplit[0]][bgSplit[1]]};` }
+            }}
+            className={'mrLabel'}
+            title={title}
+            onClick={(event) => createNewTab(event, pipeline.web_url)}
+        >
+            {icon}
+        </Label>
+    );
+};


### PR DESCRIPTION
The pipeline statuses are now displayed for each MR, + the UI has been clarified for mergeable MRs.

Closes #47 

![image](https://user-images.githubusercontent.com/4266283/211524902-f02bb6c0-6a1a-40d0-add5-d2b46d6b42ed.png)
